### PR TITLE
Add Visual C++ 2022 redist (x64) check to MSI installer

### DIFF
--- a/ScheduleReboot/Product.wxs
+++ b/ScheduleReboot/Product.wxs
@@ -5,6 +5,13 @@
         </Property>
         <Launch Condition="Installed OR (WINDOWSBUILDNUMBER &gt;= 17763)" Message="This application require Windows 10 version 1809 (build 17763) or newer." />
 
+        <!-- VC_redist 2015-2022 x64 UpgradeCode from https://stackoverflow.com/questions/35872374/detect-presence-of-vcredist-using-the-upgradecode
+             Minimum version obtained by downloading "Visual C++ Redistributable for Visual Studio 2022" (x64) 17.2 from https://my.visualstudio.com/Downloads and checking the EXE file version. -->
+        <Upgrade Id="36F68A90-239C-34DF-B58C-64B30153CE35">
+            <UpgradeVersion OnlyDetect="yes" Property="VCREDIST_X64" Minimum="14.32.31332.0" />
+        </Upgrade>
+        <Launch Condition="Installed OR VCREDIST_X64" Message="Microsoft Visual C++ 2015-2022 (x64) Redistributable missing or too old." />
+
         <!-- Disable downgrades, prevent side-by-side installations of same version -->
         <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." AllowSameVersionUpgrades="yes" />
         <!-- Embed binaries inside MSI instead of separate CAB files -->


### PR DESCRIPTION
Fail installation if the x64 C++ redistributable is either older than the first 2022 version, or is not installed.

Error message:  
![image](https://github.com/user-attachments/assets/bdfdc69d-b8fd-497b-b82e-3896f67e82f2)


Version screenshot of first VC redist 2022 17.2 version:  
![image](https://github.com/user-attachments/assets/11e52b37-265e-4d1e-804b-d345526dc9d7)
